### PR TITLE
Add additional commands, response errors and projector info poller

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Python **3** library to query and control Sony Projectors using SDCP (PJ Talk) p
 ##Features:
 * Autodiscover projector using SDAP (Simple Display Advertisement Protocol)
 * Query and change power, input and picture muting status
+* Query lamp hours
 * Toggle input between HDMI-1 and HDMI-2
 * Set aspect ratio/zoom and calibration presets
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ Python **3** library to query and control Sony Projectors using SDCP (PJ Talk) p
 
 ##Features:
 * Autodiscover projector using SDAP (Simple Display Advertisement Protocol)
-* Query and change power status
+* Query and change power, input and picture muting status
 * Toggle input between HDMI-1 and HDMI-2
+* Set aspect ratio/zoom and calibration presets
 
 ## More features
 The SDCP protocol allow to control practically everything in projector, i.e. resolution, brightness, 3d format...
 If you need to use more commands, just add to _protocol.py_, and send with _my_projector._send_command__
+Please note that commands in `COMMANDS_IR` work as fire and forget and you only get a response if there is a timeout.
 
 ### Protocol Documentation:
 * [Link](https://www.digis.ru/upload/iblock/f5a/VPL-VW320,%20VW520_ProtocolManual.pdf)
@@ -22,6 +24,7 @@ Supported Sony projectors should include:
 * VPL-HW65ES
 * VPL-VW100
 * VPL-VW260
+* VPL-VW270
 * VPL-VW285
 * VPL-VW315
 * VPL-VW320

--- a/pysdcp/__init__.py
+++ b/pysdcp/__init__.py
@@ -181,6 +181,46 @@ class Projector:
         self.ip = addr[0]
         self.is_init = True
 
+    def get_serial(self, udp_ip: str = None, udp_port: int = None, timeout=None):
+
+        self.UDP_PORT = udp_port if udp_port is not None else self.UDP_PORT
+        self.UDP_IP = udp_ip if udp_ip is not None else self.UDP_IP
+        timeout = timeout if timeout is not None else self.UDP_TIMEOUT
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+        sock.bind((self.UDP_IP, self.UDP_PORT))
+
+        sock.settimeout(timeout)
+        try:
+            SDAP_buffer, addr = sock.recvfrom(1028)
+        except socket.timeout as e:
+            return False
+        
+        serial = unpack('>I', SDAP_buffer[20:24])[0]
+
+        return serial
+    
+    def get_model(self, udp_ip: str = None, udp_port: int = None, timeout=None):
+
+        self.UDP_PORT = udp_port if udp_port is not None else self.UDP_PORT
+        self.UDP_IP = udp_ip if udp_ip is not None else self.UDP_IP
+        timeout = timeout if timeout is not None else self.UDP_TIMEOUT
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+        sock.bind((self.UDP_IP, self.UDP_PORT))
+
+        sock.settimeout(timeout)
+        try:
+            SDAP_buffer, addr = sock.recvfrom(1028)
+        except socket.timeout as e:
+            return False
+        
+        model = decode_text_field(SDAP_buffer[8:20])
+
+        return model
+
     def set_power(self, on=True):
         self._send_command(action=ACTIONS["SET"], command=COMMANDS["SET_POWER"],
                            data=POWER_STATUS["START_UP"] if on else POWER_STATUS["STANDBY"])

--- a/pysdcp/__init__.py
+++ b/pysdcp/__init__.py
@@ -259,6 +259,11 @@ class Projector:
         self._send_command(action=ACTIONS["SET"], command=COMMANDS["PICTURE_MUTING"],
                            data=PICTURE_MUTING["ON"] if on else PICTURE_MUTING["OFF"])
         return True
+    
+    def get_lamp_hours(self):
+        data = self._send_command(action=ACTIONS["GET"], command=COMMANDS["GET_STATUS_LAMP_TIMER"])
+        hours = "{:d}".format(data)
+        return hours
 
 
 if __name__ == '__main__':

--- a/pysdcp/protocol.py
+++ b/pysdcp/protocol.py
@@ -1,4 +1,3 @@
-
 # Defines and protocol details from here: https://www.digis.ru/upload/iblock/f5a/VPL-VW320,%20VW520_ProtocolManual.pdf
 
 ACTIONS = {
@@ -6,22 +5,87 @@ ACTIONS = {
     "SET": 0x00
 }
 
+#Command
+
+#Fire and forget, no response from the projector
+COMMANDS_IR = {
+    #PROJECTOR=17, PROJECTOR-E=19, PROJECTOR-EE=1B
+    "MENU": 0x1729,
+    "CURSOR_RIGHT": 0x1733,
+    "CURSOR_LEFT": 0x1734,
+    "CURSOR_UP": 0x1735,
+    "CURSOR_DOWN": 0x1736,
+    "CURSOR_ENTER": 0x175A,
+    "LENS_SHIFT_UP": 0x1772,
+    "LENS_SHIFT_DOWN": 0x1773,
+    "LENS_SHIFT_LEFT": 0x1902,
+    "LENS_SHIFT_RIGHT": 0x1903,
+    "LENS_FOCUS_FAR": 0x1774,
+    "LENS_FOCUS_NEAR": 0x1775,
+    "LENS_ZOOM_LARGE": 0x1777,
+    "LENS_ZOOM_SMALL": 0x1778,
+}
+
 COMMANDS = {
     "SET_POWER": 0x0130,
     "CALIBRATION_PRESET": 0x0002,
+    "LAMP_CONTROL": 0x001A,
+    "MOTIONFLOW": 0x0059,
+    "HDR": 0x007C,
+    "INPUT_LAG_REDUCTION": 0x0099,
+    "PICTURE_POSITION": 0x0066,
     "ASPECT_RATIO": 0x0020,
+    "HDMI1_DYNAMIC_RANGE": 0x006E,
+    "HDMI2_DYNAMIC_RANGE": 0x006F,
+    "2D_3D_SELECT": 0x0060,
+    "3D_FORMAT": 0x0060,
     "INPUT": 0x0001,
+    "PICTURE_MUTING": 0x0030,
     "GET_STATUS_ERROR": 0x0101,
     "GET_STATUS_POWER": 0x0102,
     "GET_STATUS_LAMP_TIMER": 0x0113,
-    "HDMI1_DYNAMIC_RANGE": 0x006E,
-    "HDMI2_DYNAMIC_RANGE": 0x006F,
-    "PICTURE_POSITION": 0x0066,
+    "STATUS": 0x00A4,
+    "MENU_POSITION": 0x00A6,
+    "TEST_PATTERN": 0x00AB,
 }
 
-INPUTS = {
-    "HDMI1": 0x002,
-    "HDMI2": 0x003,
+#Data
+
+CALIBRATION_PRESETS = {
+    "CINEMA_FILM_1": 0x0000,
+    "CINEMA_FILM_2": 0x0001,
+    "REF": 0x0002,
+    "TV": 0x0003,
+    "PHOTO": 0x0004,
+    "GAME": 0x0005,
+    "BRIGHT_CINEMA": 0x0006,
+    "BRIGHT_TV": 0x0007,
+    "USER": 0x0008,
+}
+
+LAMP_CONTROL= {
+    "LOW": 0x0000,
+    "HIGH": 0x0001,
+}
+
+MOTIONFLOW = {
+    "OFF": 0x0000,
+    "SMOTH_HIGH": 0x0001,
+    "SMOTH_LOW": 0x0002,
+    "IMPULSE": 0x0003,
+    "COMBINATION": 0x0004,
+    "TRUE_CINEMA": 0x0004
+}
+
+HDR = {
+    "OFF": 0x0000,
+    "ON": 0x0001,
+    "AUTO": 0x0002,
+}
+
+INPUT_LAG_REDUCTION= {
+    "OFF": 0x0000,
+    "ON": 0x0001,
 }
 
 PICTURE_POSITIONS = {
@@ -45,6 +109,56 @@ DYNAMIC_RANGES = {
     "AUTO": 0x0000,
     "LIMITED": 0x0001,
     "FULL": 0x0002
+}
+
+TWO_D_THREE_D_SELECT = {
+    "AUTO": 0x0000,
+    "3D": 0x0001,
+    "2D": 0x0002,
+}
+
+THREE_D_FORMATS = {
+    "SIMULATED_3D": 0x0000,
+    "SIDE_BY_SIDE": 0x0001,
+    "OVER_UNDER": 0x0002,
+}
+
+INPUTS = {
+    "HDMI1": 0x002,
+    "HDMI2": 0x003,
+}
+
+PICTURE_MUTING = {
+    "OFF": 0x0000,
+    "ON": 0x0001,
+}
+
+STATUS = {
+    "OFF": 0x0000,
+    "ON": 0x0001,
+}
+
+MENU_POSITIONS= {
+    "BOTTOM_LEFT": 0x0000,
+    "CENTER": 0x0001,
+}
+
+TEST_PATTERN= {
+    "OFF": 0x0000,
+    "ON": 0x0001,
+}
+
+#Response data
+
+ERROR_STATUS = {
+    "NO_ERROR": 0,
+    "LAMP_ERROR": 1,
+    "FAN_ERROR": 2,
+    "COVER_ERROR": 4,
+    "TEMP_ERROR": 8,
+    "D5V_ERROR": 10,
+    "POWER_ERROR": 20,
+    "TEMP_WARNING": 40,
 }
 
 POWER_STATUS = {

--- a/pysdcp/protocol.py
+++ b/pysdcp/protocol.py
@@ -37,16 +37,14 @@ COMMANDS = {
     "ASPECT_RATIO": 0x0020,
     "HDMI1_DYNAMIC_RANGE": 0x006E,
     "HDMI2_DYNAMIC_RANGE": 0x006F,
-    "2D_3D_SELECT": 0x0060,
-    "3D_FORMAT": 0x0060,
+    "2D_3D_DISPLAY_SELECT": 0x0060,
+    "3D_FORMAT": 0x0061,
     "INPUT": 0x0001,
     "PICTURE_MUTING": 0x0030,
+    "MENU_POSITION": 0x00A6,
     "GET_STATUS_ERROR": 0x0101,
     "GET_STATUS_POWER": 0x0102,
     "GET_STATUS_LAMP_TIMER": 0x0113,
-    "STATUS": 0x00A4,
-    "MENU_POSITION": 0x00A6,
-    "TEST_PATTERN": 0x00AB,
 }
 
 #Data
@@ -74,7 +72,7 @@ MOTIONFLOW = {
     "SMOTH_LOW": 0x0002,
     "IMPULSE": 0x0003,
     "COMBINATION": 0x0004,
-    "TRUE_CINEMA": 0x0004
+    "TRUE_CINEMA": 0x0005
 }
 
 HDR = {
@@ -133,19 +131,9 @@ PICTURE_MUTING = {
     "ON": 0x0001,
 }
 
-STATUS = {
-    "OFF": 0x0000,
-    "ON": 0x0001,
-}
-
 MENU_POSITIONS= {
     "BOTTOM_LEFT": 0x0000,
     "CENTER": 0x0001,
-}
-
-TEST_PATTERN= {
-    "OFF": 0x0000,
-    "ON": 0x0001,
 }
 
 #Response data
@@ -168,4 +156,29 @@ POWER_STATUS = {
     "POWER_ON": 3,
     "COOLING": 4,
     "COOLING2": 5
+}
+
+RESPONSE_ERRORS = {
+    0x101: "Item Error: Invalid Item",
+    0x102: "Item Error: Invalid Item Request",
+    0x103: "Item Error: Invalid Length",
+    0x104: "Item Error: Invalid Data",
+    0x111: "Item Error: Short Data",
+    0x180: "Item Error: Not Applicable Item",
+    0x201: "Community Error: Different Community",
+    0x1001: "Request Error: Invalid Version",
+    0x1002: "Request Error: Invalid Category",
+    0x1003: "Request Error: Invalid Request",
+    0x1011: "Request Error: Short Header",
+    0x1012: "Request Error: Short Community",
+    0x1013: "Request Error: Short Command",
+    0xF001: "Comm Error: Timeout",
+    0xF010: "Comm Error: Check Sum Error",
+    0xF020: "Comm Error: Framing Error",
+    0xF030: "Comm Error: Parity Error",
+    0xF040: "Comm Error: Over Run Error",
+    0xF050: "Comm Error: Other Comm Error",
+    0xF0F0: "Comm Error: Unknown Response",
+    0xF110: "NVRAM Error: Read Error",
+    0xF120: "NVRAM Error: Write Error",
 }


### PR DESCRIPTION
This adds new commands to protocol.py as well as support for "simulated ir commands" for which the projector doesn't send any return data. I also added all response error descriptions that will be shown in the exception message for the _send_command function. Additionally I added a command to get the projectors serial, model and ip.